### PR TITLE
Multi source files option

### DIFF
--- a/bash/easyoptions.sh
+++ b/bash/easyoptions.sh
@@ -61,7 +61,7 @@ show_error() {
 }
 
 parse_documentation() {
-    documentation="$(cat "$0" $easyoptions_include | grep "^##")(no-trim)"
+    documentation="$(cat "$(which "$0")" "${easyoptions_include[@]}" | grep "^##")(no-trim)"
     documentation=$(echo "$documentation" | sed -r "s/## ?//" | sed -r "s/@script.name/$(basename "$0")/g" | sed "s/@#/@/g")
     documentation=${documentation%(no-trim)}
 }

--- a/bash/easyoptions.sh
+++ b/bash/easyoptions.sh
@@ -61,7 +61,7 @@ show_error() {
 }
 
 parse_documentation() {
-    documentation="$(grep "^##" "$(which "$0")")(no-trim)"
+    documentation="$(cat "$0" $easyoptions_include | grep "^##")(no-trim)"
     documentation=$(echo "$documentation" | sed -r "s/## ?//" | sed -r "s/@script.name/$(basename "$0")/g" | sed "s/@#/@/g")
     documentation=${documentation%(no-trim)}
 }

--- a/bash/example.sh
+++ b/bash/example.sh
@@ -21,8 +21,9 @@
 ##                             format.
 
   script_dir=$(dirname "$BASH_SOURCE")
-  source "${script_dir}/../easyoptions" || exit # Ruby implementation
-# source "${script_dir}/easyoptions.sh" || exit # Bash implementation, slower
+  easyoptions_include="${script_dir}/some_sourced_lib.sh ${script_dir}/that_other_lib.sh"
+# source "${script_dir}/../easyoptions" || exit # Ruby implementation
+  source "${script_dir}/easyoptions.sh" || exit # Bash implementation, slower
 
 # Boolean and parameter options
 [[ -n "$some_option"  ]] && echo "Option specified: --some-option"
@@ -33,3 +34,9 @@
 for argument in "${arguments[@]}"; do
     echo "Argument specified: $argument"
 done
+
+source "${script_dir}/some_sourced_lib.sh"
+some-lib-feature
+
+source "${script_dir}/that_other_lib.sh"
+that-other-feature

--- a/bash/example.sh
+++ b/bash/example.sh
@@ -21,7 +21,7 @@
 ##                             format.
 
   script_dir=$(dirname "$BASH_SOURCE")
-  easyoptions_include="${script_dir}/some_sourced_lib.sh ${script_dir}/that_other_lib.sh"
+  easyoptions_include=("${script_dir}/some_sourced_lib.sh" "${script_dir}/that_other_lib.sh")
 # source "${script_dir}/../easyoptions" || exit # Ruby implementation
   source "${script_dir}/easyoptions.sh" || exit # Bash implementation, slower
 

--- a/bash/some_sourced_lib.sh
+++ b/bash/some_sourced_lib.sh
@@ -1,0 +1,5 @@
+##     -s, --some-lib-option   This is an additional option.
+some-lib-feature()
+{
+    [[ -n "$some_lib_option" ]] && echo "Some lib option: $some_lib_option"
+}

--- a/bash/that_other_lib.sh
+++ b/bash/that_other_lib.sh
@@ -1,0 +1,6 @@
+##     -t, --that-option       That is the option.
+that-other-feature()
+{
+    [[ -n "$that_option" ]] && echo "That other option: $that_option"
+}
+


### PR DESCRIPTION
Hello

I needed easyoptions to parse documentation on bash sourced scripts for additional options.
So I added a variable `$easyoptions_include` to the Bash implementation.
_(You can see it in the `bash/example.sh` file)_

If you want to include this to your awesome work, I'm happy to share :)